### PR TITLE
Fix basic install links on guide pages

### DIFF
--- a/guides/cloning/gh-two-factor/index.md
+++ b/guides/cloning/gh-two-factor/index.md
@@ -5,7 +5,7 @@ title: GitHub Two Factor Auth Guide
 description: How to clone with GitHub Two Factor Authorization
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../../install)
 first.**
 
 [Return to all guides](../../)

--- a/guides/cloning/index.md
+++ b/guides/cloning/index.md
@@ -5,7 +5,7 @@ title: HTTP/HTTPS Guide
 description: How to clone with HTTP/HTTPS
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../install)
 first.**
 
 [Return to all guides](../)

--- a/guides/cloning/ssh-with-agent/index.md
+++ b/guides/cloning/ssh-with-agent/index.md
@@ -5,7 +5,7 @@ title: SSH w/ Agent Guide
 description: How to clone with SSH using an agent
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../../install)
 first.**
 
 [Return to all guides](../../)

--- a/guides/repositories/index.md
+++ b/guides/repositories/index.md
@@ -5,7 +5,7 @@ title: Opening a Repository
 description: How to open and free a repository
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../install)
 first.**
 
 [Return to all guides](../)

--- a/guides/repositories/initializing/index.md
+++ b/guides/repositories/initializing/index.md
@@ -5,7 +5,7 @@ title: Initializing
 description: How to initialize a repository
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../../install)
 first.**
 
 [Return to all guides](../../)


### PR DESCRIPTION
The links on the top of the guide pages were not linked properly to the basic install page.