### PR TITLE
Updated Remote Methods

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -1261,6 +1261,8 @@ sections:
 | [<span>Remote.</span>isValidName <span>(remote_name)</span>](/api/remote/#isValidName) |  <span class="tags"><span class="sync">Sync</span></span> |
 | [<span>Remote.</span>list <span>(repo)</span>](/api/remote/#list) |  <span class="tags"><span class="async">Async</span></span> |
 | [<span>Remote.</span>lookup <span>(repo, name, callback)</span>](/api/remote/#lookup) |  <span class="tags"><span class="async">Async</span></span> |
+| [<span>Remote.</span>setPushurl <span>(repo, name, url)</span>](/api/remote/#setPushurl) |  <span class="tags"><span class="sync">Sync</span></span> |
+| [<span>Remote.</span>setUrl <span>(repo, name, url)</span>](/api/remote/#setUrl) |  <span class="tags"><span class="sync">Sync</span></span> |
 
 | Instance Methods |  |
 | --- | ---: |
@@ -1289,9 +1291,7 @@ sections:
 | [<span>Remote#</span>save <span>()</span>](/api/remote/#save) |  <span class="tags"><span class="sync">Sync</span></span> |
 | [<span>Remote#</span>setAutotag <span>(value)</span>](/api/remote/#setAutotag) |  <span class="tags"><span class="sync">Sync</span></span> |
 | [<span>Remote#</span>setCallbacks <span>(callbacks)</span>](/api/remote/#setCallbacks) |  <span class="tags"><span class="sync">Sync</span></span> |
-| [<span>Remote#</span>setPushurl <span>(url)</span>](/api/remote/#setPushurl) |  <span class="tags"><span class="sync">Sync</span></span> |
 | [<span>Remote#</span>setUpdateFetchhead <span>(value)</span>](/api/remote/#setUpdateFetchhead) |  <span class="tags"><span class="sync">Sync</span></span> |
-| [<span>Remote#</span>setUrl <span>(url)</span>](/api/remote/#setUrl) |  <span class="tags"><span class="sync">Sync</span></span> |
 | [<span>Remote#</span>stats <span>()</span>](/api/remote/#stats) |  <span class="tags"><span class="sync">Sync</span></span> |
 | [<span>Remote#</span>stop <span>()</span>](/api/remote/#stop) |  <span class="tags"><span class="sync">Sync</span></span> |
 | [<span>Remote#</span>updateFetchhead <span>()</span>](/api/remote/#updateFetchhead) |  <span class="tags"><span class="sync">Sync</span></span> |
@@ -1787,5 +1787,3 @@ sections:
 | [<span>Treebuilder#</span>insert <span>(filename, id, filemode)</span>](/api/treebuilder/#insert) |  <span class="tags"><span class="async">Async</span><span class="experimental">Experimental</span></span> |
 | [<span>Treebuilder#</span>remove <span>(filename)</span>](/api/treebuilder/#remove) |  <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span> |
 | [<span>Treebuilder#</span>write <span>(id)</span>](/api/treebuilder/#write) |  <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span> |
-
-

--- a/api/remote/index.md
+++ b/api/remote/index.md
@@ -188,6 +188,38 @@ Retrieves the remote by name
 | --- | --- |
 | [Remote](/api/remote/) |  |
 
+## <a name="setUrl"></a><span>Remote.</span>setUrl <span class="tags"><span class="sync">Sync</span></span>
+
+```js
+var result = Remote.setUrl(repo, name, url);
+```
+
+| Parameters | Type |
+| --- | --- | --- |
+| repo | [Repository](/api/repository/) | The repo that the remote lives in |
+| name | String | The name of the remote to modify |
+| url | String | the url to set |
+
+| Returns |  |
+| --- | --- |
+| Number |  0 or an error value |
+
+## <a name="setPushurl"></a><span>Remote.</span>setPushurl <span class="tags"><span class="sync">Sync</span></span>
+
+```js
+var result = Remote.setPushurl(repo, name, url);
+```
+
+| Parameters | Type |
+| --- | --- | --- |
+| repo | [Repository](/api/repository/) | The repo that the remote lives in |
+| name | String | The name of the remote to modify |
+| url | String | the url to set or NULL to clear the pushurl |
+
+| Returns |  |
+| --- | --- |
+| Number |  0 or an error value |
+
 ## <a name="addFetch"></a><span>Remote#</span>addFetch <span class="tags"><span class="sync">Sync</span></span>
 
 ```js
@@ -480,20 +512,6 @@ var result = remote.setCallbacks(callbacks);
 | --- | --- |
 | Number |  0 or an error code |
 
-## <a name="setPushurl"></a><span>Remote#</span>setPushurl <span class="tags"><span class="sync">Sync</span></span>
-
-```js
-var result = remote.setPushurl(url);
-```
-
-| Parameters | Type |
-| --- | --- | --- |
-| url | String | the url to set or NULL to clear the pushurl |
-
-| Returns |  |
-| --- | --- |
-| Number |  0 or an error value |
-
 ## <a name="setUpdateFetchhead"></a><span>Remote#</span>setUpdateFetchhead <span class="tags"><span class="sync">Sync</span></span>
 
 ```js
@@ -503,20 +521,6 @@ remote.setUpdateFetchhead(value);
 | Parameters | Type |
 | --- | --- | --- |
 | value | Number | 0 to disable updating FETCH_HEAD |
-
-## <a name="setUrl"></a><span>Remote#</span>setUrl <span class="tags"><span class="sync">Sync</span></span>
-
-```js
-var result = remote.setUrl(url);
-```
-
-| Parameters | Type |
-| --- | --- | --- |
-| url | String | the url to set |
-
-| Returns |  |
-| --- | --- |
-| Number |  0 or an error value |
 
 ## <a name="stats"></a><span>Remote#</span>stats <span class="tags"><span class="sync">Sync</span></span>
 
@@ -599,4 +603,3 @@ var string = remote.url();
 | <span>Remote.COMPLETION_TYPE.</span>COMPLETION_DOWNLOAD | 0 |
 | <span>Remote.COMPLETION_TYPE.</span>COMPLETION_INDEXING | 1 |
 | <span>Remote.COMPLETION_TYPE.</span>COMPLETION_ERROR | 2 |
-


### PR DESCRIPTION
Moved `remote.setUrl` and `remote.setPushurl` to Class Methods of `NodeGit.Remote` and changed the method signatures to reflect the actual implementation.