### PR TITLE
Fixed Issue #53

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -1065,8 +1065,8 @@ sections:
 | [<span>Object.</span>lookup <span>(repo, id, type)</span>](/api/object/#lookup) |  <span class="tags"><span class="async">Async</span><span class="experimental">Experimental</span></span> |
 | [<span>Object.</span>lookupPrefix <span>(repo, id, len, type)</span>](/api/object/#lookupPrefix) |  <span class="tags"><span class="async">Async</span><span class="experimental">Experimental</span></span> |
 | [<span>Object.</span>size <span>(type)</span>](/api/object/#size) |  <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span> |
-| [<span>Object.</span>string2type <span>(str)</span>](/api/object/#string2type) |  <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span> |
-| [<span>Object.</span>type2string <span>(type)</span>](/api/object/#type2string) |  <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span> |
+| [<span>Object.</span>string2Type <span>(str)</span>](/api/object/#string2Type) |  <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span> |
+| [<span>Object.</span>type2String <span>(type)</span>](/api/object/#type2String) |  <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span> |
 | [<span>Object.</span>typeisloose <span>(type)</span>](/api/object/#typeisloose) |  <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span> |
 
 | Instance Methods |  |

--- a/api/object/index.md
+++ b/api/object/index.md
@@ -10,8 +10,8 @@ sections:
   "lookup": "#lookup"
   "lookupPrefix": "#lookupPrefix"
   "size": "#size"
-  "string2type": "#string2type"
-  "type2string": "#type2string"
+  "string2Type": "#string2Type"
+  "type2String": "#type2String"
   "typeisloose": "#typeisloose"
   "#dup": "#dup"
   "#free": "#free"
@@ -75,10 +75,10 @@ var result = Object.size(type);
 | --- | --- |
 | Number |  size in bytes of the object |
 
-## <a name="string2type"></a><span>Object.</span>string2type <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span>
+## <a name="string2Type"></a><span>Object.</span>string2Type <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span>
 
 ```js
-var result = Object.string2type(str);
+var result = Object.string2Type(str);
 ```
 
 | Parameters | Type |   |
@@ -89,10 +89,10 @@ var result = Object.string2type(str);
 | --- | --- |
 | Number |  the corresponding git_otype. |
 
-## <a name="type2string"></a><span>Object.</span>type2string <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span>
+## <a name="type2String"></a><span>Object.</span>type2String <span class="tags"><span class="sync">Sync</span><span class="experimental">Experimental</span></span>
 
 ```js
-var string = Object.type2string(type);
+var string = Object.type2String(type);
 ```
 
 | Parameters | Type |   |


### PR DESCRIPTION
Fixed the documentation on both the API page and the Object page. Corrected two Object function names, from 'string2type' and 'type2string', to 'string2Type' and 'type2String'.